### PR TITLE
Add javafx instructions for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ To run, you need the Java Runtime Environment with version `8 u 40` or higher. W
 
 If you have Java installed, simply opening the `.jar` or `.app` is enough to launch Smart Mod Inserter. 
 
+#### Linux Users
+
+JavaFX is required and may not be installed by default. On Ubuntu, you can fix this by installing these packages:
+
+    sudo apt-get install openjdk-8-jre openjfx libopenjfx-java
+
 ### First launch
 
 Upon first launching Smart Mod Inserter, it will probably ask you to define the factorio application path and the data path. On some setups, it will automatically be able to figure out some of those paths. Until you have all necessary paths selected, the close button will stay disabled.


### PR DESCRIPTION
Without this, launching the jar gave me a "class not found error" for Main, which was clearly not the correct error.

Installing the library fixed it, and I threw in the Java 8 package for good measure.
