### PR TITLE
Auto detect windows factorio application path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,5 +115,10 @@
             <artifactId>org.ow2.sat4j.core</artifactId>
             <version>2.3.5</version>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>4.2.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
+++ b/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
@@ -2,27 +2,17 @@ package com.narrowtux.fmm;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.narrowtux.fmm.gui.GuiFiles;
-import com.narrowtux.fmm.gui.ModsTabController;
-import com.narrowtux.fmm.gui.SavesTabController;
+import com.narrowtux.fmm.gui.*;
 import com.narrowtux.fmm.io.URISchemeHandler;
 import com.narrowtux.fmm.io.dirwatch.SimpleDirectoryWatchService;
-import com.narrowtux.fmm.gui.MainWindowController;
-import com.narrowtux.fmm.gui.SettingsWindowController;
 import com.narrowtux.fmm.io.tasks.TaskService;
 import com.narrowtux.fmm.model.Datastore;
 import com.narrowtux.fmm.util.OS;
-import com.narrowtux.fmm.util.OSXAppleEventHelper;
 import com.narrowtux.fmm.util.Util;
 import com.narrowtux.fmm.util.WindowsUtil;
 import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.application.Preloader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.Alert;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.Dialog;
 import javafx.stage.Stage;
 
 import java.io.FileReader;
@@ -30,12 +20,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Base64;
-import java.util.logging.Logger;
 
 public class FactorioModManagerApplication extends Application {
-    private static final Logger LOGGER = Logger.getLogger(FactorioModManagerApplication.class.getName());
-
     private SettingsWindowController settingsWindowController;
     private Stage settingsStage;
 
@@ -139,18 +125,15 @@ public class FactorioModManagerApplication extends Application {
 
         for (Path parentCandidate : optionalFactorioInstallDirectoryParents) {
             if (parentCandidate == null) continue;
-            LOGGER.info("Searching " + parentCandidate.toString() + " for Factorio application");
 
             for (String subpathCandidate : possibleFactorioApplicationSubpaths) {
                 Path candidateExePath = parentCandidate.resolve(subpathCandidate);
                 if (Files.exists(candidateExePath) && !Files.isDirectory(candidateExePath)) {
-                    LOGGER.info("Found factorio application at " + candidateExePath);
                     return candidateExePath;
                 }
             }
         }
 
-        LOGGER.warning("Could not find Factorio application");
         return null;
     }
 

--- a/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
+++ b/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
@@ -55,7 +55,7 @@ public class FactorioModManagerApplication extends Application {
                 store.setDataDir(appData.resolve("factorio"));
                 store.setStorageDir(appData.resolve("FactorioModManager"));
 
-                Path maybeSteamPath = WindowsUtil.TryGetSteamPathFromRegistry();
+                Path maybeSteamPath = WindowsUtil.getSteamPathFromRegistry();
                 Path maybeSteamAppsCommonPath = maybeSteamPath != null ? maybeSteamPath.resolve("SteamApps\\Common") : null;
 
                 store.setFactorioApplication(lookForFactorioApplicationUnder(

--- a/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
+++ b/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
@@ -77,20 +77,12 @@ public class FactorioModManagerApplication extends Application {
                 store.setStorageDir(Paths.get(xdgConf, "FactorioModManager"));
                 store.setDataDir(Paths.get(System.getenv("HOME"), ".factorio"));
 
-                Path[] possibleExe = {
+                setFactorioApplicationToFirstExistingPath(store,
                     Paths.get("/usr/bin/factorio"),
                     Paths.get(xdgData, "steam/SteamApps/common/Factorio/bin/x64/factorio"),
                     Paths.get(xdgData, "steam/SteamApps/common/Factorio/bin/i386/factorio"),
                     Paths.get(System.getenv("HOME"), "factorio/bin/x64/factorio"),
-                    Paths.get(System.getenv("HOME"), "factorio/bin/i386/factorio"),
-                };
-
-                for (Path exePath : possibleExe) {
-                    if (Files.exists(exePath)) {
-                        store.setFactorioApplication(exePath);
-                        break;
-                    }
-                }
+                    Paths.get(System.getenv("HOME"), "factorio/bin/i386/factorio"));
             }
 
             Path settingsPath = store.getStorageDir().resolve("settings.json");
@@ -123,6 +115,15 @@ public class FactorioModManagerApplication extends Application {
         } catch (Exception e) {
             e.printStackTrace();
             throw e;
+        }
+    }
+
+    private void setFactorioApplicationToFirstExistingPath(Datastore store, Path... possibleApplicationPaths) {
+        for (Path exePath : possibleApplicationPaths) {
+            if (Files.exists(exePath)) {
+                store.setFactorioApplication(exePath);
+                break;
+            }
         }
     }
 

--- a/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
+++ b/src/main/java/com/narrowtux/fmm/FactorioModManagerApplication.java
@@ -14,6 +14,7 @@ import com.narrowtux.fmm.model.Datastore;
 import com.narrowtux.fmm.util.OS;
 import com.narrowtux.fmm.util.OSXAppleEventHelper;
 import com.narrowtux.fmm.util.Util;
+import com.narrowtux.fmm.util.WindowsUtil;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.application.Preloader;
@@ -65,6 +66,16 @@ public class FactorioModManagerApplication extends Application {
                 Path appData = Paths.get(System.getenv("AppData"));
                 store.setDataDir(appData.resolve("factorio"));
                 store.setStorageDir(appData.resolve("FactorioModManager"));
+
+                Path steamPath = WindowsUtil.TryGetSteamPathFromRegistry();
+                Path programFiles = Paths.get(System.getenv("PROGRAMFILES"));
+                Path programFilesX86 = Paths.get(System.getenv("PROGRAMFILES(X86)"));
+
+                setFactorioApplicationToFirstExistingPath(store,
+                    steamPath.resolve("SteamApps\\common\\Factorio\\bin\\x64\\Factorio.exe"),
+                    steamPath.resolve("SteamApps\\common\\Factorio\\bin\\i386\\Factorio.exe"),
+                    programFiles.resolve("\\Factorio\\bin\\x64\\Factorio.exe"),
+                    programFilesX86.resolve("\\Factorio\\bin\\i386\\Factorio.exe"));
             } else {
                 String xdgConf = System.getenv("XDG_CONFIG_DIR");
                 String xdgData = System.getenv("XDG_DATA_HOME");

--- a/src/main/java/com/narrowtux/fmm/util/Util.java
+++ b/src/main/java/com/narrowtux/fmm/util/Util.java
@@ -12,6 +12,8 @@ import javafx.scene.Node;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
@@ -193,5 +195,11 @@ public class Util {
                 thread.interrupt();
             }
         }
+    }
+
+    public static Path tryGetEnvPath(String environementVariableName) {
+        String maybeEnvValue = System.getenv(environementVariableName);
+        if (maybeEnvValue == null) return null;
+        return Paths.get(maybeEnvValue);
     }
 }

--- a/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
+++ b/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
@@ -1,0 +1,14 @@
+package com.narrowtux.fmm.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.WinReg;
+
+public class WindowsUtil {
+    public static Path TryGetSteamPathFromRegistry() {
+        String pathStringFromRegistry = Advapi32Util.registryGetStringValue(
+                WinReg.HKEY_CURRENT_USER, "SOFTWARE\\Valve\\Steam", "SteamPath");
+        return Paths.get(pathStringFromRegistry);
+    }
+}

--- a/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
+++ b/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
@@ -2,13 +2,24 @@ package com.narrowtux.fmm.util;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.logging.Logger;
+
 import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinReg;
 
 public class WindowsUtil {
+    private static final Logger LOGGER = Logger.getLogger(WindowsUtil.class.getName());
+
     public static Path TryGetSteamPathFromRegistry() {
-        String pathStringFromRegistry = Advapi32Util.registryGetStringValue(
-                WinReg.HKEY_CURRENT_USER, "SOFTWARE\\Valve\\Steam", "SteamPath");
-        return Paths.get(pathStringFromRegistry);
+        try {
+            String pathStringFromRegistry = Advapi32Util.registryGetStringValue(
+                    WinReg.HKEY_CURRENT_USER, "SOFTWARE\\Valve\\Steam", "SteamPath");
+            LOGGER.info("Found SteamPath from registry: " + pathStringFromRegistry);
+            return Paths.get(pathStringFromRegistry);
+        } catch(Win32Exception e) {
+            LOGGER.warning("Could not find SteamPath in registry, Steam is probably not installed");
+            return null;
+        }
     }
 }

--- a/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
+++ b/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
@@ -8,7 +8,13 @@ import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinReg;
 
 public class WindowsUtil {
-    public static Path TryGetSteamPathFromRegistry() {
+    /**
+     * Returns the path to the root Steam installation directory (typically C:\Program Files\Steam),
+     * or null if Steam is not installed.
+     *
+     * Call only on Windows.
+     */
+    public static Path getSteamPathFromRegistry() {
         try {
             String pathStringFromRegistry = Advapi32Util.registryGetStringValue(
                     WinReg.HKEY_CURRENT_USER, "SOFTWARE\\Valve\\Steam", "SteamPath");

--- a/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
+++ b/src/main/java/com/narrowtux/fmm/util/WindowsUtil.java
@@ -2,23 +2,18 @@ package com.narrowtux.fmm.util;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.Logger;
 
 import com.sun.jna.platform.win32.Advapi32Util;
 import com.sun.jna.platform.win32.Win32Exception;
 import com.sun.jna.platform.win32.WinReg;
 
 public class WindowsUtil {
-    private static final Logger LOGGER = Logger.getLogger(WindowsUtil.class.getName());
-
     public static Path TryGetSteamPathFromRegistry() {
         try {
             String pathStringFromRegistry = Advapi32Util.registryGetStringValue(
                     WinReg.HKEY_CURRENT_USER, "SOFTWARE\\Valve\\Steam", "SteamPath");
-            LOGGER.info("Found SteamPath from registry: " + pathStringFromRegistry);
             return Paths.get(pathStringFromRegistry);
         } catch(Win32Exception e) {
-            LOGGER.warning("Could not find SteamPath in registry, Steam is probably not installed");
             return null;
         }
     }


### PR DESCRIPTION
Adds logic that attempts to guess the Factorio application path on Windows using a similar priority order to the one currently used on Linux:

1) Looks in the Steam installation folder (as indicated by the registry) for x64 and then x86 installations
2) Looks in Program Files for an x64 non-steam installation
3) Looks in Program Files (x86) for an x86 non-steam installation

Note that this involves taking a new dependency (jna-platform, https://github.com/java-native-access/jna) for the native registry access required to identify the steam installation folder. JNA is well-maintained and apache licensed.

The following scenarios were tested:
Windows (Windows 10 Pro x64 10586.318):
- Installed via Steam with a non-default Steam folder
- Installed non-Steam (x64)
- No installs (falls back to the settings window as before)
- No installs with no Steam installation and no PROGRAMFILES(X86) (falls back to settings window, does not throw)
